### PR TITLE
remove hhbm from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
 php:
   - '7.0'
-  - hhvm
   - nightly


### PR DESCRIPTION
it was causing build issues, and i dont actually ever use hhvm (and it wouldn't surprise me if hhb_var_dump doesn't work properly with hhvm, either)